### PR TITLE
[POC] Slack notifications imply they list individual vulnerabilities,…

### DIFF
--- a/rego-templates/vuls-html.rego
+++ b/rego-templates/vuls-html.rego
@@ -13,6 +13,7 @@ tpl:=`
 <p>%s</p>
 <p>%s</p>
 <!-- stats -->
+<h3>Vulnerabilities summary</h2>
 %s
 <h2>Assurance controls</h2>
 %s


### PR DESCRIPTION
… but they do not.

Response Policies | Slack integration | Slack API has issues when the number of blocks in the json payload is greater than 10 in some fields

1) the headline "found vulnerabilities" will appear only if there are vulnerabilities to show.
2) adding "Vulnerabilities summary" headline to slack
3) adding "Vulnerabilities summary" headline to html

SLK-53323 SLK-53206