### PR TITLE
[POC] Slack notifications imply they list individual vulnerabilities,…

### DIFF
--- a/rego-templates/vuls-slack.rego
+++ b/rego-templates/vuls-slack.rego
@@ -133,15 +133,6 @@ result = res {
 
     ])
 
-    checks_performed2:= flat_array([check |
-                        item := input.image_assurance_results.checks_performed[i]
-                        check:= [
-                            {"type": "mrkdwn", "text": sprintf("%d %s", [i+1, item.control])},
-                            {"type": "mrkdwn", "text": concat(" / ", [item.policy_name, by_flag("FAIL", "PASS", check_failed(item))])}
-                        ]
-
-        ])
-
     severity_stats:= flat_array([gr |
             severity := severities[_]
             gr:= [


### PR DESCRIPTION
… but they do not.

Response Policies | Slack integration | Slack API has issues when the number of blocks in the json payload is greater than 10 in some fields

1) removing leftover

SLK-53323 SLK-53206